### PR TITLE
Removes conditional to register file_picker plugin on android platform

### DIFF
--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
@@ -40,12 +40,6 @@ public class FilePickerPlugin implements MethodCallHandler {
   /** Plugin registration. */
   public static void registerWith(Registrar registrar) {
 
-    if (registrar.activity() == null) {
-        // If a background flutter view tries to register the plugin, there will be no activity from the registrar,
-        // we stop the registering process immediately because the ImagePicker requires an activity.
-        return;
-    }
-
     final MethodChannel channel = new MethodChannel(registrar.messenger(), "file_picker");
     channel.setMethodCallHandler(new FilePickerPlugin());
 


### PR DESCRIPTION
Having an activity when the plugin tries to register itself implies to change the way we are registering all plugins. Because of that and because `ImagePicker` plugin is no longer a file_picker dependency since version [1.3.0](https://github.com/miguelpruivo/flutter_file_picker/blob/master/CHANGELOG.md#130), we are removing the conditional that is preventing the `file_picker` plugin be registered. (See the comment inside the conditional block to understand why I am talking about ImagePicker)